### PR TITLE
Add portability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,10 @@ cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_CXX_STANDARD 11)
 
-# TODO: make InfluxDB optional
-find_package(InfluxDB REQUIRED)
+find_package(InfluxDB)
 
 set(COMMON_SOURCES
     src/DataProcessor.cpp
-    src/InfluxDBProducer.cpp
     src/LocalHost.cpp
     src/Measurement.cpp
     src/ObisData.cpp
@@ -24,22 +22,30 @@ set(COMMON_SOURCES
     src/SpeedwireSocket.cpp
     src/SpeedwireSocketFactory.cpp
     src/SpeedwireSocketSimple.cpp
-    src/main.cpp
 )
 
-add_executable(${PROJECT_NAME}
+add_library(${PROJECT_NAME} STATIC
     ${COMMON_SOURCES}
 )
 
-if (InfluxDB_FOUND)
-    target_link_libraries(${PROJECT_NAME} InfluxData::InfluxDB)
-endif (InfluxDB_FOUND)
-
 target_include_directories(${PROJECT_NAME}
-PRIVATE
+PUBLIC
     include
 )
 
-install(TARGETS ${PROJECT_NAME}
-    RUNTIME DESTINATION bin
-)
+if (InfluxDB_FOUND)
+    add_executable(${PROJECT_NAME}-bin
+        src/InfluxDBProducer.cpp
+        src/main.cpp
+    )
+    target_link_libraries(${PROJECT_NAME}-bin
+        ${PROJECT_NAME}
+        InfluxData::InfluxDB
+    )
+    set_target_properties(${PROJECT_NAME}-bin
+        PROPERTIES OUTPUT_NAME ${PROJECT_NAME}
+    )
+    install(TARGETS ${PROJECT_NAME}
+        RUNTIME DESTINATION bin
+    )
+endif (InfluxDB_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,45 @@
+project(emeter-grabber)
+
+cmake_minimum_required(VERSION 3.10)
+
+set(CMAKE_CXX_STANDARD 11)
+
+# TODO: make InfluxDB optional
+find_package(InfluxDB REQUIRED)
+
+set(COMMON_SOURCES
+    src/DataProcessor.cpp
+    src/InfluxDBProducer.cpp
+    src/LocalHost.cpp
+    src/Measurement.cpp
+    src/ObisData.cpp
+    src/ObisFilter.cpp
+    src/SpeedwireByteEncoding.cpp
+    src/SpeedwireCommand.cpp
+    src/SpeedwireData.cpp
+    src/SpeedwireDiscovery.cpp
+    src/SpeedwireEmeterProtocol.cpp
+    src/SpeedwireHeader.cpp
+    src/SpeedwireInverterProtocol.cpp
+    src/SpeedwireSocket.cpp
+    src/SpeedwireSocketFactory.cpp
+    src/SpeedwireSocketSimple.cpp
+    src/main.cpp
+)
+
+add_executable(${PROJECT_NAME}
+    ${COMMON_SOURCES}
+)
+
+if (InfluxDB_FOUND)
+    target_link_libraries(${PROJECT_NAME} InfluxData::InfluxDB)
+endif (InfluxDB_FOUND)
+
+target_include_directories(${PROJECT_NAME}
+PRIVATE
+    include
+)
+
+install(TARGETS ${PROJECT_NAME}
+    RUNTIME DESTINATION bin
+)

--- a/include/DataProcessor.hpp
+++ b/include/DataProcessor.hpp
@@ -8,7 +8,9 @@
 #include <SpeedwireData.hpp>
 #include <Measurement.hpp>
 #include <ObisFilter.hpp>
-#include <InfluxDB.h>
+
+
+class Producer;
 
 
 class DataProcessor : public ObisConsumer, SpeedwireConsumer {
@@ -23,20 +25,15 @@ protected:
     uint32_t      speedwire_currentTimestamp;
     bool          speedwire_currentTimestampIsValid;
     bool          speedwire_averagingTimeReached;
-    std::unique_ptr<influxdb::InfluxDB> influxDB;
-    influxdb::Point                     influxPoint;
+    Producer&     producer;
 
 public:
 
-    DataProcessor(const unsigned long averagingTime);
+    DataProcessor(const unsigned long averagingTime, Producer& producer);
     ~DataProcessor(void);
 
     virtual void consume(const ObisData &element);
     virtual void consume(const SpeedwireData& element);
-    void flush(void);
-
-    void produce(const std::string &device, const MeasurementType &type, const Line, const double value);
-
 };
 
 #endif

--- a/include/InfluxDBProducer.hpp
+++ b/include/InfluxDBProducer.hpp
@@ -1,0 +1,26 @@
+#ifndef __INFLUXDBEXPORT_HPP__
+#define __INFLUXDBEXPORT_HPP__
+
+#include <memory>               // for std::unique_ptr
+#include <Measurement.hpp>
+#include <InfluxDB.h>
+#include <Producer.hpp>
+
+
+class InfluxDBProducer : public Producer {
+
+protected:
+    std::unique_ptr<influxdb::InfluxDB> influxDB;
+    influxdb::Point                     influxPoint;
+
+public:
+
+    InfluxDBProducer(void);
+    ~InfluxDBProducer(void);
+
+    void flush(void) override;
+    void produce(const std::string &device, const MeasurementType &type, const Line, const double value) override;
+
+};
+
+#endif

--- a/include/Producer.hpp
+++ b/include/Producer.hpp
@@ -1,0 +1,16 @@
+#ifndef __PRODUCER_HPP__
+#define __PRODUCER_HPP__
+
+#include <Measurement.hpp>
+
+
+/**
+ *  Interface to be implemented by any producer like InfluxDBProducer.
+ */
+class Producer {
+public:
+    virtual void flush(void) = 0;
+    virtual void produce(const std::string &device, const MeasurementType &type, const Line, const double value) = 0;
+};
+
+#endif

--- a/src/DataProcessor.cpp
+++ b/src/DataProcessor.cpp
@@ -1,15 +1,11 @@
 #include <stdio.h>
 #include <DataProcessor.hpp>
 #include <Measurement.hpp>
-#include <InfluxDBFactory.h>
+#include <Producer.hpp>
 
 
-DataProcessor::DataProcessor(const unsigned long averagingTime) :  
-  //influxDB(influxdb::InfluxDBFactory::Get("udp://localhost:8094/?db=test")),
-    influxDB(influxdb::InfluxDBFactory::Get("http://localhost:8086/?db=test")),
-  //influxDB(influxdb::InfluxDBFactory::Get("http://192.168.178.16:8086/?db=test")),
-    influxPoint("sma_emeter") {
-    influxDB->batchOf(100);
+DataProcessor::DataProcessor(const unsigned long averagingTime, Producer& producer) :
+    producer(producer) {
     this->averagingTime = averagingTime;
     this->obis_remainder = 0;
     this->obis_currentTimestamp = 0;
@@ -64,7 +60,7 @@ void DataProcessor::consume(const ObisData &element) {
             } else {
                 value = measurement->value;
             }
-            produce("meter", element.measurementType, element.line, value);
+            producer.produce("meter", element.measurementType, element.line, value);
         }
     }
 }
@@ -112,42 +108,7 @@ void DataProcessor::consume(const SpeedwireData& element) {
             else {
                 value = measurement->value;
             }
-            produce("inverter", element.measurementType, element.line, value);
+            producer.produce("inverter", element.measurementType, element.line, value);
         }
     }
-}
-
-
-void DataProcessor::flush(void) {
-    influxDB.get()->flushBuffer();
-}
-
-
-void DataProcessor::produce(const std::string &device, const MeasurementType &type, const Line line, const double value) {
-    fprintf(stderr, "%s  %lf\n", type.getFullName(line).c_str(), value);
-
-    influxPoint.addTag("device", device);
-
-    std::string str_direction(toString(type.direction));
-    std::string str_quantity(toString(type.quantity));
-    std::string str_type(toString(type.type));
-    std::string str_line(toString(line));
-    if (str_direction.length() > 0) {
-        influxPoint.addTag("direction", str_direction);
-    }
-    if (str_quantity.length() > 0) {
-        influxPoint.addTag("quantity", str_quantity);
-    }
-    if (str_type.length() > 0) {
-        influxPoint.addTag("type", str_type);
-    }
-    if (str_line.length() > 0) {
-        influxPoint.addTag("line", str_line);
-    }
-
-    influxPoint = influxPoint.addField("value", value);
-
-    std::string name = influxPoint.getName();
-    influxDB.get()->write(std::move(influxPoint));
-    influxPoint = influxdb::Point(name);
 }

--- a/src/InfluxDBProducer.cpp
+++ b/src/InfluxDBProducer.cpp
@@ -1,0 +1,48 @@
+#include <InfluxDBProducer.hpp>
+#include <InfluxDBFactory.h>
+
+
+InfluxDBProducer::InfluxDBProducer(void) :
+  //influxDB(influxdb::InfluxDBFactory::Get("udp://localhost:8094/?db=test")),
+    influxDB(influxdb::InfluxDBFactory::Get("http://localhost:8086/?db=test")),
+  //influxDB(influxdb::InfluxDBFactory::Get("http://192.168.178.16:8086/?db=test")),
+    influxPoint("sma_emeter") {
+    influxDB->batchOf(100);
+}
+
+InfluxDBProducer::~InfluxDBProducer(void) {}
+
+
+void InfluxDBProducer::flush(void) {
+    influxDB.get()->flushBuffer();
+}
+
+
+void InfluxDBProducer::produce(const std::string &device, const MeasurementType &type, const Line line, const double value) {
+    fprintf(stderr, "%s  %lf\n", type.getFullName(line).c_str(), value);
+
+    influxPoint.addTag("device", device);
+
+    std::string str_direction(toString(type.direction));
+    std::string str_quantity(toString(type.quantity));
+    std::string str_type(toString(type.type));
+    std::string str_line(toString(line));
+    if (str_direction.length() > 0) {
+        influxPoint.addTag("direction", str_direction);
+    }
+    if (str_quantity.length() > 0) {
+        influxPoint.addTag("quantity", str_quantity);
+    }
+    if (str_type.length() > 0) {
+        influxPoint.addTag("type", str_type);
+    }
+    if (str_line.length() > 0) {
+        influxPoint.addTag("line", str_line);
+    }
+
+    influxPoint = influxPoint.addField("value", value);
+
+    std::string name = influxPoint.getName();
+    influxDB.get()->write(std::move(influxPoint));
+    influxPoint = influxdb::Point(name);
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,7 @@
 #include <SpeedwireDiscovery.hpp>
 #include <ObisFilter.hpp>
 #include <DataProcessor.hpp>
+#include <InfluxDBProducer.hpp>
 
 
 static int poll_emeters(const std::vector<SpeedwireSocket>& sockets, struct pollfd* const fds, const int poll_emeter_timeout_in_ms, ObisFilter& filter);
@@ -90,7 +91,8 @@ int main(int argc, char **argv) {
     query_map.add(SpeedwireData::InverterRelay);
 
     // configure processing chain
-    DataProcessor processor(60000);
+    InfluxDBProducer producer;
+    DataProcessor processor(60000, producer);
     filter.addConsumer(&processor);
     SpeedwireCommand command(localhost, discoverer.getDevices());
 
@@ -128,7 +130,7 @@ int main(int argc, char **argv) {
         // poll sockets for inbound emeter packets
         int npackets = poll_emeters(sockets, fds, poll_emeter_timeout_in_ms, filter);
         if (npackets > 0) {
-            processor.flush();
+            producer.flush();
         }
 
         // if the query interval has elapsed for the inverters, start a query
@@ -142,7 +144,7 @@ int main(int argc, char **argv) {
                     printf("QUERY INVERTER  time 0x%016llx\n", localhost.getTickCountInMs());
                     int nreplies = query_inverter(device, command, query_map, processor, needs_login, night_mode);
                     if (nreplies > 0) {
-                        processor.flush();
+                        producer.flush();
                     }
                 }
             }


### PR DESCRIPTION
Hi and thanks for your effort to create this library.

My plan is, to reuse this lib within SBFsport to read energy meter data. Therefore, i did some adaptions to make this a little more portable:
- InfluxDB is not mandatory anymore at source code level. InfluxDB related stuff has now a dedicated class (InfluxDBProducer).
- Add CMake support
- Add MacOSX support

I hope, this is of help. Please share your thoughts. Thanks!